### PR TITLE
feat: encapsulate logger debug, warn, error api

### DIFF
--- a/log/backend.log
+++ b/log/backend.log
@@ -1,1 +1,4 @@
 {"level":"info","ts":"2024-02-07T23:39:19.312+0800","msg":"test info","func":"main.main","file":"/Users/yuerfei/Documents/SWJTU/Year3/SoftwareProject/repo/api.backend.xjco2913/cmd/main.go","line":10}
+{"level":"debug","ts":"2024-02-08T15:48:45.706+0800","msg":"debug msg","type":"debug","func":"zlog_test.TestLogger","file":"/Users/yuerfei/Documents/SWJTU/Year3/SoftwareProject/repo/api.backend.xjco2913/util/zlog/zlog_test.go","line":11}
+{"level":"warn","ts":"2024-02-08T15:48:45.706+0800","msg":"warn msg","type":"warn","func":"zlog_test.TestLogger","file":"/Users/yuerfei/Documents/SWJTU/Year3/SoftwareProject/repo/api.backend.xjco2913/util/zlog/zlog_test.go","line":12}
+{"level":"error","ts":"2024-02-08T15:48:45.706+0800","msg":"error msg","error":true,"func":"zlog_test.TestLogger","file":"/Users/yuerfei/Documents/SWJTU/Year3/SoftwareProject/repo/api.backend.xjco2913/util/zlog/zlog_test.go","line":13}

--- a/log/error.log
+++ b/log/error.log
@@ -1,0 +1,1 @@
+{"level":"error","ts":"2024-02-08T15:48:45.706+0800","msg":"error msg","error":true,"func":"zlog_test.TestLogger","file":"/Users/yuerfei/Documents/SWJTU/Year3/SoftwareProject/repo/api.backend.xjco2913/util/zlog/zlog_test.go","line":13}

--- a/util/zlog/zlog.go
+++ b/util/zlog/zlog.go
@@ -20,13 +20,17 @@ func init() {
 
 	encoder := zapcore.NewJSONEncoder(encoderConfig)
 
-	file, _ := os.OpenFile("./log/backend.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 644)
+	file, _ := os.OpenFile("../../log/backend.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	fileWriterSyncer := zapcore.AddSync(file)
+
+	errFile, _ := os.OpenFile("../../log/error.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	errFileWriterSyncer := zapcore.AddSync(errFile)
 
 	// print into both stdout and log file
 	core := zapcore.NewTee(
 		zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), zapcore.DebugLevel),
 		zapcore.NewCore(encoder, fileWriterSyncer, zapcore.DebugLevel),
+		zapcore.NewCore(encoder, errFileWriterSyncer, zapcore.ErrorLevel),
 	)
 
 	localLogger = zap.New(core)
@@ -36,6 +40,24 @@ func Info(msg string, fields ...zap.Field) {
 	callerFields := getCaller()
 	fields = append(fields, callerFields...)
 	localLogger.Info(msg, fields...)
+}
+
+func Debug(msg string, fields ...zap.Field) {
+	callFields := getCaller()
+	fields = append(fields, callFields...)
+	localLogger.Debug(msg, fields...)
+}
+
+func Warn(msg string, fields ...zap.Field) {
+	callFields := getCaller()
+	fields = append(fields, callFields...)
+	localLogger.Warn(msg, fields...)
+}
+
+func Error(msg string, fields ...zap.Field) {
+	callFields := getCaller()
+	fields = append(fields, callFields...)
+	localLogger.Error(msg, fields...)
 }
 
 func getCaller() []zap.Field {

--- a/util/zlog/zlog_test.go
+++ b/util/zlog/zlog_test.go
@@ -1,0 +1,14 @@
+package zlog_test
+
+import (
+	"testing"
+
+	"api.backend.xjco2913/util/zlog"
+	"go.uber.org/zap"
+)
+
+func TestLogger(t *testing.T) {
+	zlog.Debug("debug msg", zap.String("type", "debug"))
+	zlog.Warn("warn msg", zap.String("type", "warn"))
+	zlog.Error("error msg", zap.Bool("error", true))
+}


### PR DESCRIPTION
1. all levels log will be printed into both `console` and `backend.log`
2. error level log will be printed into both `console` and `error.log`